### PR TITLE
Upgrade Play + scalatestplus-play / https port is now disabled by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
 enablePlugins(PlayScala)
 scalaVersion := "2.13.10"
 libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M4" % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0-RC3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M5")

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -2,12 +2,8 @@ package controllers
 
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
-import play.api.{Application, Configuration}
 import play.api.test._
 import play.api.test.Helpers._
-import play.server.api.SSLEngineProvider
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLEngine
 
 class HomeControllerSpec extends PlaySpec with GuiceOneServerPerSuite {
 
@@ -19,21 +15,4 @@ class HomeControllerSpec extends PlaySpec with GuiceOneServerPerSuite {
       }
     }
   }
-
-  private[this] val factory = new DefaultTestServerFactory {
-    override def overrideServerConfiguration(app: Application): Configuration =
-      Configuration("play.server.https.engineProvider" -> classOf[MySSLEngineProvider].getName)
-  }
-
-  override protected final implicit lazy val runningServer: RunningServer =
-    factory.start(app)
-}
-
-
-class MySSLEngineProvider extends SSLEngineProvider {
-  override def createSSLEngine(): SSLEngine =
-    sslContext().createSSLEngine()
-
-  override def sslContext(): SSLContext =
-    SSLContext.getDefault
 }


### PR DESCRIPTION
@xuwei-k This is fixed now. Please give it a try on JDK 20. Works for me.

* Reverts your workaround
* Upgrades to latest Play 2.9 milestone + scalatestplus-play which now disables the https port by default (also uses random ports now)
